### PR TITLE
migration bug

### DIFF
--- a/database/migrations/2018_04_29_074240_add_lang_country_column_to_users_table.php
+++ b/database/migrations/2018_04_29_074240_add_lang_country_column_to_users_table.php
@@ -13,9 +13,13 @@ class AddLangCountryColumnToUsersTable extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->string('lang_country')->after('email')->nullable();
-        });
+        if (!Schema::hasColumn('users', 'lang_country')) {
+
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('lang_country')->after('email')->nullable();
+            });
+
+        }
     }
 
     /**a

--- a/database/migrations/2018_04_29_074240_add_lang_country_column_to_users_table.php
+++ b/database/migrations/2018_04_29_074240_add_lang_country_column_to_users_table.php
@@ -13,12 +13,10 @@ class AddLangCountryColumnToUsersTable extends Migration
      */
     public function up()
     {
-        if (!Schema::hasColumn('users', 'lang_country')) {
-
+        if (! Schema::hasColumn('users', 'lang_country')) {
             Schema::table('users', function (Blueprint $table) {
                 $table->string('lang_country')->after('email')->nullable();
             });
-
         }
     }
 


### PR DESCRIPTION
## Description
If the `users` table already has an `lang_country` column, an error occurs while running the migrations.
This PR will check first if the column exists.