### PR TITLE
Automatic support for default Laravel authentication system Login event

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,8 +62,15 @@ protected $fillable = [
 ];
 ```
 
-To make sure this will be loaded and stored in the session add this to method to
-your `app\Http\Controllers\Auth\LoginController.php`:
+### Login event listener
+
+By default, the package will listen to the `Illuminate\Auth\Events\Login` event. When this event is fired, the package
+will set the right sessions for the newly logged-in user based on the users database preferences.
+The `Illuminate\Auth\Events\Login` event is dispatched when you're using the default Laravel authentication system (
+Breeze/Jetstream).
+
+If you're using a custom authentication system, you need to add the following to the code that is being handled after a
+user is logged in:
 
 ```php
 public function authenticated(Request $request, $user)
@@ -73,7 +80,7 @@ public function authenticated(Request $request, $user)
         \LangCountry::setAllSessions($user->lang_country);
     }
 
-    return redirect()->intended($this->redirectPath());
+    //...
 }
 ```
 

--- a/src/LaravelLangCountryServiceProvider.php
+++ b/src/LaravelLangCountryServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace Stefro\LaravelLangCountry;
 
+use Illuminate\Auth\Events\Login;
 use Illuminate\Support\ServiceProvider;
+use Stefro\LaravelLangCountry\Listeners\UserAuthenticated;
+use Stefro\LaravelLangCountry\Middleware\LangCountrySession;
 
 class LaravelLangCountryServiceProvider extends ServiceProvider
 {
@@ -19,12 +22,14 @@ class LaravelLangCountryServiceProvider extends ServiceProvider
 
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
 
-        $this->app['router']->aliasMiddleware('lang_country', \Stefro\LaravelLangCountry\Middleware\LangCountrySession::class);
+        $this->app['router']->aliasMiddleware('lang_country', LangCountrySession::class);
 
         $this->app['router']
             ->middleware(config('lang-country.lang_switcher_middleware'))
             ->get('/change_lang_country/{lang_country}', 'Stefro\LaravelLangCountry\Controllers\LangCountrySwitchController@switch')
             ->name('lang_country.switch');
+
+        \Event::listen(Login::class, UserAuthenticated::class);
     }
 
     /**

--- a/src/Listeners/UserAuthenticated.php
+++ b/src/Listeners/UserAuthenticated.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Stefro\LaravelLangCountry\Listeners;
+
+class UserAuthenticated
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(object $event): void
+    {
+        // Set the right sessions
+        if (null != $event->user->lang_country) {
+            \LangCountry::setAllSessions($event->user->lang_country);
+        }
+    }
+}

--- a/tests/Feature/Listeners/UserAuthenticatedTest.php
+++ b/tests/Feature/Listeners/UserAuthenticatedTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Stefro\LaravelLangCountry\Tests\Support\Models\User;
+
+beforeEach(function () {
+    // Set config variables
+    $this->app['config']->set('lang-country.fallback', 'en-GB');
+    $this->app['config']->set('lang-country.allowed', [
+        'nl-NL',
+        'nl-BE',
+        'en-GB',
+        'en-US',
+    ]);
+});
+
+it('should set all sessions when the user is logged in by listening to the Login event', function () {
+    $user = User::create([
+        'name' => 'Stef Rouschop',
+        'email' => 'hello@hello.com',
+        'password' => \Hash::make('password'),
+        'lang_country' => 'nl_NL',
+    ]);
+
+    Auth::login($user);
+
+    expect(session('locale'))->toBe('nl')->and(session('lang_country'))->toBe('nl-NL');
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
By default, the package will now listen to the `Illuminate\Auth\Events\Login` event. When this event is fired, the package
will set the right sessions for the newly logged-in user based on the users database preferences.
The `Illuminate\Auth\Events\Login` event is dispatched when you're using the default Laravel authentication system (
Breeze/Jetstream).

## Motivation and context
https://github.com/stefro/laravel-lang-country/issues/43

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
