### PR TITLE
Added customization for Language Switcher's uri

### DIFF
--- a/config/lang-country.php
+++ b/config/lang-country.php
@@ -27,5 +27,7 @@ return [
 
     'lang_switcher_middleware' => ['web'],
 
+    'lang_switcher_uri' => 'change_lang_country',
+
     'fallback_based_on_current_locale' => false,
 ];

--- a/src/LaravelLangCountryServiceProvider.php
+++ b/src/LaravelLangCountryServiceProvider.php
@@ -26,7 +26,7 @@ class LaravelLangCountryServiceProvider extends ServiceProvider
 
         $this->app['router']
             ->middleware(config('lang-country.lang_switcher_middleware'))
-            ->get('/change_lang_country/{lang_country}', 'Stefro\LaravelLangCountry\Controllers\LangCountrySwitchController@switch')
+            ->get('/' . config('lang-country.lang_switcher_uri') . '/{lang_country}', 'Stefro\LaravelLangCountry\Controllers\LangCountrySwitchController@switch')
             ->name('lang_country.switch');
 
         \Event::listen(Login::class, UserAuthenticated::class);

--- a/src/LaravelLangCountryServiceProvider.php
+++ b/src/LaravelLangCountryServiceProvider.php
@@ -26,7 +26,7 @@ class LaravelLangCountryServiceProvider extends ServiceProvider
 
         $this->app['router']
             ->middleware(config('lang-country.lang_switcher_middleware'))
-            ->get('/' . config('lang-country.lang_switcher_uri') . '/{lang_country}', 'Stefro\LaravelLangCountry\Controllers\LangCountrySwitchController@switch')
+            ->get('/' . config('lang-country.lang_switcher_uri','change_lang_country') . '/{lang_country}', 'Stefro\LaravelLangCountry\Controllers\LangCountrySwitchController@switch')
             ->name('lang_country.switch');
 
         \Event::listen(Login::class, UserAuthenticated::class);


### PR DESCRIPTION
It is now possible to set custom URI for Language Switcher. It's ready for customization in **config/lang-country.php**.